### PR TITLE
MOD: adjust messaging

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,12 +1,27 @@
+// When the extension is installed or updated,
+// initialize the badge text to empty.
 chrome.runtime.onInstalled.addListener(() => {
   chrome.action.setBadgeText({
     text: '',
   })
 })
 
+// Listen for messages from the content script requesting the active state
+chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+  if (request.type === 'GET_ACTIVE_STATE') {
+    // Check current badge text; respond with true if it's 'ON'
+    chrome.action
+      .getBadgeText({ tabId: sender.tab.id })
+      .then((badgeText) => sendResponse(badgeText === 'ON'))
+
+    // Must return true to indicate we will use sendResponse asynchronously
+    return true
+  }
+})
+
+// Listen for clicks on the extension's action button (the icon)
 chrome.action.onClicked.addListener(async (tab) => {
   const prevState = await chrome.action.getBadgeText({ tabId: tab.id })
-
   const nextState = prevState === 'ON' ? '' : 'ON'
 
   await chrome.action.setBadgeText({
@@ -14,8 +29,23 @@ chrome.action.onClicked.addListener(async (tab) => {
     text: nextState,
   })
 
-  chrome.scripting.executeScript({
-    target: { tabId: tab.id },
-    files: ['showImageSizes.js'],
-  })
+  // First try to inject the script
+  try {
+    await chrome.scripting.executeScript({
+      target: { tabId: tab.id },
+      files: ['showImageSizes.js'],
+    })
+
+    // Only send message after successful script injection
+    try {
+      chrome.tabs.sendMessage(tab.id, {
+        type: 'TOGGLE_STATE',
+        enabled: nextState === 'ON',
+      })
+    } catch (e) {
+      // tab no longer exists
+    }
+  } catch (e) {
+    // script injection failed
+  }
 })


### PR DESCRIPTION
Right now, you are polluting the `document` with `showImagesSizes`. That's probably not ideal. My approach was now to load the script and then send a message to the tab. It could also be done with two separate scripts to load and unload the functionality. I was now taking that route since it's closer to your approach.